### PR TITLE
fix(ios): fallback to fullResolutionImage when tempCopyMediaFile returns nil

### DIFF
--- a/dw_image_picker_ios/ios/Classes/DWImagePickerPlugin.swift
+++ b/dw_image_picker_ios/ios/Classes/DWImagePickerPlugin.swift
@@ -262,6 +262,11 @@ public class DWImagePickerPlugin: NSObject, FlutterPlugin, DW_TLPhotosPickerView
                         group.leave();
                     })
                     if result == nil {
+                        if let uiImage = asset.fullResolutionImage,
+                           let imageInfo = DWImagePickerUtils.copyImage(uiImage, quality: compressQuality, format: compressFormat, id: asset.phAsset?.localIdentifier) {
+                            let media = NSDictionary(dictionary: imageInfo)
+                            data.append(media)
+                        }
                         group.leave();
                     }
                 }


### PR DESCRIPTION
## Problem

When using `openPicker` on iOS, `PICKER_ERROR` is returned if all selected assets fail to export. This happens because `tempCopyMediaFile` can return `nil` for various reasons (e.g. iCloud assets not yet downloaded to device, PHAsset resource temporarily unavailable, etc.), and the code simply calls `group.leave()` without adding any data, resulting in an empty `data` array that triggers `PICKER_ERROR`.

## Fix

When `tempCopyMediaFile` returns `nil`, fallback to reading the asset via `fullResolutionImage` and saving it with `DWImagePickerUtils.copyImage()`. This provides a graceful degradation path instead of returning a generic error to the user.

## Testing

Tested with:
- Local photos (works as before)
- iCloud photos not fully downloaded (previously PICKER_ERROR, now succeeds with fallback)